### PR TITLE
feat(frontend): refine navigation, branding

### DIFF
--- a/frontend/src/app/home/page.tsx
+++ b/frontend/src/app/home/page.tsx
@@ -8,20 +8,20 @@ import { useCategories } from "@/hooks/useCategories";
 
 export default function Home() {
   const { isAuthenticated, isLoading, user, logout } = useAuth();
-  const [activeTab, setActiveTab] = useState("Overview");
+  const [activeTab, setActiveTab] = useState("Visão geral");
 
   // Fetch data from API
   const { data: dashboardData, isLoading: dashboardLoading } = useDashboard();
   const { data: lowStockData, isLoading: lowStockLoading } = useLowStockProducts();
   const { data: categoriesData, isLoading: categoriesLoading } = useCategories();
 
-  const tabs = ["Overview", "Analytics", "Reports"];
+  const tabs = ["Visão geral"];
 
   const metrics = [
     {
-      title: "Total Products",
-      value: `${dashboardData?.totalProducts || 0} products`,
-      change: "+12% from last month",
+      title: "Total de produtos",
+      value: `${dashboardData?.totalProducts || 0} produtos`,
+      change: "+12% em relação ao mês passado",
       changeType: "positive",
       icon: (
         <svg
@@ -43,9 +43,9 @@ export default function Home() {
       ),
     },
     {
-      title: "Total Stock Value",
-      value: `$${dashboardData?.totalStockValue || 0}`,
-      change: "+8% from last month",
+      title: "Valor total do estoque",
+      value: `R$ ${dashboardData?.totalStockValue || 0}`,
+      change: "+8% em relação ao mês passado",
       changeType: "positive",
       icon: (
         <svg
@@ -66,9 +66,9 @@ export default function Home() {
       ),
     },
     {
-      title: "Low Stock",
-      value: `${dashboardData?.lowStockProductsCount || 0} products`,
-      change: "Need restocking",
+      title: "Estoque baixo",
+      value: `${dashboardData?.lowStockProductsCount || 0} produtos`,
+      change: "Necessita reposição",
       changeType: (dashboardData?.lowStockProductsCount || 0) > 0 ? "negative" : "positive",
       icon: (
         <svg
@@ -116,13 +116,13 @@ export default function Home() {
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-bold text-gray-900">Dashboard</h1>
-          <p className="text-gray-600">Welcome back, {user?.firstName || 'User'}!</p>
+          <p className="text-gray-600">Bem-vindo de volta, {user?.firstName || 'Usuário'}!</p>
         </div>
         <button
           onClick={logout}
           className="bg-red-600 text-white px-4 py-2 rounded-md hover:bg-red-700"
         >
-          Logout
+          Sair
         </button>
       </div>
 
@@ -182,7 +182,7 @@ export default function Home() {
       {/* Recent Activities */}
       <div className="bg-white rounded-lg shadow-sm border border-gray-200">
         <div className="p-6 border-b border-gray-200">
-          <h2 className="text-lg font-semibold text-gray-900">Recent Activities</h2>
+          <h2 className="text-lg font-semibold text-gray-900">Atividades recentes</h2>
         </div>
         <div className="p-6">
           {dashboardLoading ? (
@@ -197,7 +197,7 @@ export default function Home() {
                     <div className="w-2 h-2 bg-red-500 rounded-full"></div>
                     <div>
                       <p className="font-medium text-gray-900">{product.name}</p>
-                      <p className="text-sm text-gray-500">Low stock: {product.stockQuantity} units</p>
+                      <p className="text-sm text-gray-500">Estoque baixo: {product.stockQuantity} unidades</p>
                     </div>
                   </div>
                   <span className="text-sm text-gray-500">{product.categoryName}</span>

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -10,7 +10,7 @@ import { AuthProvider } from "@/contexts/AuthContext";
 const inter = Inter({ subsets: ["latin"], variable: "--font-sans" });
 
 export const metadata: Metadata = {
-  title: "ShopSense Dashboard",
+  title: "Hypesoft Dashboard",
   description: "Product Management System for Hypesoft Technical Challenge",
 };
 
@@ -48,30 +48,25 @@ export default function RootLayout({
                 <line x1="12" x2="12" y1="22.08" y2="12"></line>
               </svg>
             </div>
-            <span className="text-xl font-bold text-gray-800">ShopSense</span>
+            <span className="text-xl font-bold text-gray-800">Hypesoft Dashboard</span>
           </div>
 
+          {/* BEGIN NAV REPLACEMENT */}
           <nav className="flex-grow">
-            <h3 className="text-xs font-semibold text-gray-500 uppercase mb-2">
-              General
-            </h3>
-            <ul>
-              <li className="mb-2">
-                <a
-                  href="/home"
-                  className="flex items-center p-2 rounded-md text-gray-700 hover:bg-gray-100"
-                >
+            <ul className="space-y-1">
+              <li>
+                <a href="/home" className="flex items-center p-2 rounded-md text-gray-700 hover:bg-gray-100">
                   <svg
                     xmlns="http://www.w3.org/2000/svg"
-                    width="20"
-                    height="20"
+                    width="18"
+                    height="18"
                     viewBox="0 0 24 24"
                     fill="none"
                     stroke="currentColor"
                     strokeWidth="2"
                     strokeLinecap="round"
                     strokeLinejoin="round"
-                    className="lucide lucide-home mr-2"
+                    className="mr-2"
                   >
                     <path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"></path>
                     <polyline points="9 22 9 12 15 12 15 22"></polyline>
@@ -79,391 +74,62 @@ export default function RootLayout({
                   Dashboard
                 </a>
               </li>
-              <li className="mb-2">
-                <a
-                  href="/categories"
-                  className="flex items-center p-2 rounded-md text-gray-700 hover:bg-gray-100"
-                >
+              <li>
+                <a href="/products" className="flex items-center p-2 rounded-md text-gray-700 hover:bg-gray-100">
                   <svg
                     xmlns="http://www.w3.org/2000/svg"
-                    width="20"
-                    height="20"
+                    width="18"
+                    height="18"
                     viewBox="0 0 24 24"
                     fill="none"
                     stroke="currentColor"
                     strokeWidth="2"
                     strokeLinecap="round"
                     strokeLinejoin="round"
-                    className="lucide lucide-tags mr-2"
-                  >
-                    <path d="M9 5H2v7l6.29-6.29A2 2 0 0 1 9 5Z"></path>
-                    <path d="M6 9.01V9"></path>
-                    <path d="m15 5 6.3 6.3a2.4 2.4 0 0 1 0 3.4L17 19"></path>
-                  </svg>
-                  Categorias
-                </a>
-              </li>
-              <li className="mb-2">
-                <a
-                  href="/products"
-                  className="flex items-center p-2 rounded-md text-gray-700 hover:bg-gray-100"
-                >
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    width="20"
-                    height="20"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    className="lucide lucide-package mr-2"
+                    className="mr-2"
                   >
                     <path d="M16.5 9.4l-9-5.19M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path>
                     <polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline>
                     <line x1="12" x2="12" y1="22.08" y2="12"></line>
                   </svg>
-                  Produtos
-                </a>
-              </li>
-              <li className="mb-4">
-                <a
-                  href="#"
-                  className="flex items-center p-2 rounded-md text-gray-700 hover:bg-gray-100"
-                >
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    width="20"
-                    height="20"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    className="lucide lucide-bar-chart-2 mr-2"
-                  >
-                    <line x1="18" x2="18" y1="20" y2="10"></line>
-                    <line x1="12" x2="12" y1="20" y2="4"></line>
-                    <line x1="6" x2="6" y1="20" y2="14"></line>
-                  </svg>
-                  Statistics
-                </a>
-              </li>
-            </ul>
-
-            <h3 className="text-xs font-semibold text-gray-500 uppercase mb-2">
-              Shop
-            </h3>
-            <ul>
-              <li className="mb-2">
-                <a
-                  href="#"
-                  className="flex items-center p-2 rounded-md text-gray-700 hover:bg-gray-100"
-                >
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    width="20"
-                    height="20"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    className="lucide lucide-store mr-2"
-                  >
-                    <path d="m2 7 4.41-4.41A2 2 0 0 1 7.41 2h9.18a2 2 0 0 1 1.4.59L22 7"></path>
-                    <path d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8"></path>
-                    <path d="M15 22v-4a2 2 0 0 0-2-2h-2a2 2 0 0 0-2 2v4"></path>
-                    <path d="M2 7h20"></path>
-                    <path d="M22 7v3a2 2 0 0 1-2 2v0a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2v0a2 2 0 0 1-2-2V7"></path>
-                  </svg>
-                  My Shop
-                </a>
-              </li>
-              <li className="mb-2">
-                <a
-                  href="#"
-                  className="flex items-center p-2 rounded-md bg-purple-50 text-purple-700 font-semibold"
-                >
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    width="20"
-                    height="20"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    className="lucide lucide-cube mr-2"
-                  >
-                    <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path>
-                    <polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline>
-                    <line x1="12" x2="12" y1="22.08" y2="12"></line>
-                  </svg>
-                  Products
-                </a>
-              </li>
-              <li className="mb-2">
-                <a
-                  href="#"
-                  className="flex items-center p-2 rounded-md text-gray-700 hover:bg-gray-100"
-                >
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    width="20"
-                    height="20"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    className="lucide lucide-users mr-2"
-                  >
-                    <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"></path>
-                    <circle cx="9" cy="7" r="4"></circle>
-                    <path d="M22 21v-2a4 4 0 0 0-3-3.87M16 3.13a4 4 0 0 1 0 7.75"></path>
-                  </svg>
-                  Customers
-                </a>
-              </li>
-              <li className="mb-2">
-                <a
-                  href="#"
-                  className="flex items-center p-2 rounded-md text-gray-700 hover:bg-gray-100"
-                >
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    width="20"
-                    height="20"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    className="lucide lucide-receipt mr-2"
-                  >
-                    <path d="M4 2v20l2-1 2 1 2-1 2 1 2-1 2 1 2-1 2 1V2l-2 1-2-1-2 1-2-1-2 1-2-1-2 1Z"></path>
-                    <path d="M14 8H8"></path>
-                    <path d="M16 12H8"></path>
-                    <path d="M16 16H8"></path>
-                  </svg>
-                  Invoice
-                </a>
-              </li>
-              <li className="mb-4">
-                <a
-                  href="#"
-                  className="flex items-center p-2 rounded-md text-gray-700 hover:bg-gray-100 relative"
-                >
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    width="20"
-                    height="20"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    className="lucide lucide-message-square mr-2"
-                  >
-                    <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path>
-                  </svg>
-                  Messages
-                  <span className="absolute top-1 right-1 bg-purple-600 text-white text-xs rounded-full px-1.5 py-0.5">
-                    4
-                  </span>
-                </a>
-              </li>
-            </ul>
-
-            <h3 className="text-xs font-semibold text-gray-500 uppercase mb-2">
-              Support
-            </h3>
-            <ul>
-              <li className="mb-2">
-                <a
-                  href="#"
-                  className="flex items-center p-2 rounded-md text-gray-700 hover:bg-gray-100"
-                >
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    width="20"
-                    height="20"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    className="lucide lucide-settings mr-2"
-                  >
-                    <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.78 1.35a2 2 0 0 0 .73 2.73l.15.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73v.56a2 2 0 0 1 1 1.73l-.15.08a2 2 0 0 0-.73 2.73l.78 1.35a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.78-1.35a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.73v-.56a2 2 0 0 1 1-1.73l.15-.08a2 2 0 0 0 .73-2.73l-.78-1.35a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25A2 2 0 0 1 12.22 2z"></path>
-                    <circle cx="12" cy="12" r="3"></circle>
-                  </svg>
-                  Settings
+                  Gestão de Produtos
                 </a>
               </li>
               <li>
-                <a
-                  href="#"
-                  className="flex items-center p-2 rounded-md text-gray-700 hover:bg-gray-100"
-                >
+                <a href="/categories" className="flex items-center p-2 rounded-md text-gray-700 hover:bg-gray-100">
                   <svg
                     xmlns="http://www.w3.org/2000/svg"
-                    width="20"
-                    height="20"
+                    width="18"
+                    height="18"
                     viewBox="0 0 24 24"
                     fill="none"
                     stroke="currentColor"
                     strokeWidth="2"
                     strokeLinecap="round"
                     strokeLinejoin="round"
-                    className="lucide lucide-help-circle mr-2"
+                    className="mr-2"
                   >
-                    <circle cx="12" cy="12" r="10"></circle>
-                    <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"></path>
-                    <path d="M12 17h.01"></path>
+                    <path d="M9 5H2v7l6.29-6.29A2 2 0 0 1 9 5Z"></path>
+                    <path d="M6 9.01V9"></path>
+                    <path d="m15 5 6.3 6.3a2.4 2.4 0 0 1 0 3.4L17 19"></path>
                   </svg>
-                  Help
+                  Sistema de Categorias
                 </a>
               </li>
             </ul>
           </nav>
+          {/* END NAV REPLACEMENT */}
 
-          <div className="mt-auto p-4 bg-purple-50 rounded-lg shadow-sm">
-            <div className="flex items-center gap-2 mb-2">
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                width="20"
-                height="20"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="#8B5CF6"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                className="lucide lucide-star"
-              >
-                <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"></polygon>
-              </svg>
-              <span className="font-semibold text-purple-700">
-                Try ShopSense Pro
-              </span>
-            </div>
-            <p className="text-sm text-gray-600 mb-4">
-              Get Pro and enjoy 20+ features to enhance your sales. Free 30 days
-              trial!
-            </p>
-            <button className="w-full bg-purple-600 text-white py-2 rounded-md hover:bg-purple-700 transition-colors">
-              Upgrade Plan
-            </button>
-          </div>
+          {/* Footer placeholder */}
+          <div className="mt-auto p-4" />
         </aside>
 
         {/* Main Content */}
         <main className="flex-1 flex flex-col bg-gray-50">
           {/* Header */}
           <header className="w-full bg-white border-b p-4 flex items-center justify-between shadow-sm">
-            <div className="flex items-center gap-4">
-              <div className="relative">
-                <select className="appearance-none bg-gray-100 border border-gray-300 text-gray-700 py-2 px-4 pr-8 rounded-md focus:outline-none focus:ring-2 focus:ring-purple-500">
-                  <option>UnitedMen</option>
-                  <option>UnitedWomen</option>
-                </select>
-                <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center px-2 text-gray-700">
-                  <svg
-                    className="fill-current h-4 w-4"
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 20 20"
-                  >
-                    <path d="M9.293 12.95l.707.707L15.657 8l-1.414-1.414L10 10.828 5.757 6.586 4.343 8z" />
-                  </svg>
-                </div>
-              </div>
-            </div>
-
-            <div className="flex items-center gap-4">
-              <button className="p-2 rounded-full hover:bg-gray-100">
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  width="24"
-                  height="24"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  className="lucide lucide-sun"
-                >
-                  <circle cx="12" cy="12" r="4"></circle>
-                  <path d="M12 2v2"></path>
-                  <path d="M12 20v2"></path>
-                  <path d="m4.93 4.93 1.41 1.41"></path>
-                  <path d="m17.66 17.66 1.41 1.41"></path>
-                  <path d="M2 12h2"></path>
-                  <path d="M20 12h2"></path>
-                  <path d="m6.34 17.66-1.41 1.41"></path>
-                  <path d="m19.07 4.93-1.41 1.41"></path>
-                </svg>
-              </button>
-              <button className="p-2 rounded-full hover:bg-gray-100 relative">
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  width="24"
-                  height="24"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  className="lucide lucide-bell"
-                >
-                  <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9"></path>
-                  <path d="M10.3 21a1.94 1.94 0 0 0 3.4 0"></path>
-                </svg>
-                <span className="absolute top-1 right-1 block h-2 w-2 rounded-full bg-red-500"></span>
-              </button>
-              <div className="flex items-center gap-2">
-                <Image
-                  src="https://api.dicebear.com/7.x/initials/svg?seed=MS"
-                  alt="Miguel Santos"
-                  width={40}
-                  height={40}
-                  className="w-10 h-10 rounded-full"
-                />
-                <div>
-                  <p className="font-semibold text-gray-800">Miguel Santos</p>
-                  <p className="text-sm text-gray-500">Shop Admin</p>
-                </div>
-              </div>
-              <button className="p-2 rounded-full hover:bg-gray-100">
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  width="24"
-                  height="24"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  className="lucide lucide-more-vertical"
-                >
-                  <circle cx="12" cy="12" r="1"></circle>
-                  <circle cx="12" cy="5" r="1"></circle>
-                  <circle cx="12" cy="19" r="1"></circle>
-                </svg>
-              </button>
-            </div>
+            <h1 className="text-lg font-semibold text-gray-800">Hypesoft Dashboard</h1>
+            <div />
           </header>
 
                     {/* Page Content */}


### PR DESCRIPTION
-simplify sidebar to core pages (Dashboard, Gestão de Produtos, Sistema de Categorias) 
-replace emojis with SVG icons aligned to prototype -update branding to “Hypesoft Dashboard”
-clean header to show only the dashboard title
-translate dashboard texts to pt-BR (cards, tabs, labels, actions) -keep existing pages intact; no new routes added