### PR TITLE
feat(api): add health checks (liveness/readiness) with Mongo probe

### DIFF
--- a/backend/src/Hypesoft.API/Hypesoft.API.csproj
+++ b/backend/src/Hypesoft.API/Hypesoft.API.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="9.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.1.0" />
+    <PackageReference Include="AspNetCore.HealthChecks.MongoDb" Version="8.0.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
-map /health/live and /health/ready
-add MongoDB health probe with timeout
-validated responses locally (HTTP 5000)